### PR TITLE
Refactor SocketConsoleServer to allow custom console class

### DIFF
--- a/sockesole/__init__.py
+++ b/sockesole/__init__.py
@@ -216,11 +216,13 @@ class SocketConsoleServer(
         buffer: int = 4096,
         queue_size: int = 5,
         clean_interval: float = 5,
+        console_cls: type[SocketConsole] = SocketConsole,
         logger: Logger = getLogger(__name__),
     ) -> None:
         self._host = host
         self._port = port
         self._queue_size = queue_size
+        self._console_cls = console_cls
         self.buffer = buffer
         self.clean_interval = clean_interval
         self.logger = logger
@@ -279,7 +281,7 @@ class SocketConsoleServer(
                 try:
                     conn, addr = server.accept()
                     self.logger.info(f"Connection from {addr}")
-                    console = SocketConsole(
+                    console = self._console_cls(
                         conn=conn,
                         client_address=addr,
                         buffer=self.buffer,


### PR DESCRIPTION
This pull request refactors the SocketConsoleServer to allow for a custom console class. Previously, the SocketConsoleServer used a specific console class, but now it can be customized by passing a different console class as an argument. This provides more flexibility and allows for easier customization of the console behavior.